### PR TITLE
R3 to put Gamepad into standby mode

### DIFF
--- a/include/menu/utils.h
+++ b/include/menu/utils.h
@@ -64,6 +64,7 @@ extern "C"
     void humanize(uint64_t size, char *out);
     void getFreeSpaceString(NUSDEV dev, char *out);
     bool showExitOverlay(bool really);
+    void checkAndDoDRCScreenOff();
 
 #ifdef __cplusplus
 }

--- a/src/downloader.c
+++ b/src/downloader.c
@@ -235,6 +235,8 @@ static bool showNetworkError(const char *err)
 
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_B)
             break;
         if(vpad.trigger & VPAD_BUTTON_Y || (autoResumeEnabled() && --frames == 0))
@@ -784,6 +786,8 @@ int downloadFile(const char *url, char *file, downloadData *data, FileType type,
 
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(cancelOverlay == NULL)
         {
             if(vpad.trigger & VPAD_BUTTON_B)
@@ -922,6 +926,8 @@ int downloadFile(const char *url, char *file, downloadData *data, FileType type,
 
                 showFrame();
 
+                checkAndDoDRCScreenOff();
+
                 if(vpad.trigger & VPAD_BUTTON_B)
                     break;
                 if(vpad.trigger & VPAD_BUTTON_Y)
@@ -960,6 +966,8 @@ int downloadFile(const char *url, char *file, downloadData *data, FileType type,
                     drawErrorFrame(toScreen, B_RETURN | Y_RETRY);
 
                 showFrame();
+
+                checkAndDoDRCScreenOff();
 
                 if(vpad.trigger & VPAD_BUTTON_B)
                     break;

--- a/src/menu/configMenu.c
+++ b/src/menu/configMenu.c
@@ -258,6 +258,8 @@ void configMenu()
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_B)
         {
             saveConfig(false);

--- a/src/menu/filebrowserMenu.c
+++ b/src/menu/filebrowserMenu.c
@@ -216,6 +216,8 @@ char *fileBrowserMenu(bool installMenu, bool allowNoIntro)
                 }
                 showFrame();
 
+                checkAndDoDRCScreenOff();
+
                 if(vpad.trigger & VPAD_BUTTON_B)
                     break;
                 if(vpad.trigger & VPAD_BUTTON_A)

--- a/src/menu/installerMenu.c
+++ b/src/menu/installerMenu.c
@@ -193,6 +193,8 @@ refreshDir:
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_B)
         {
             MEMFreeToDefaultHeap((TMD *)tmd);

--- a/src/menu/insttitlebrowserMenu.c
+++ b/src/menu/insttitlebrowserMenu.c
@@ -303,6 +303,8 @@ loopEntry:
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_PLUS)
         {
             launchTitle(ititleEntries + cursor + pos);
@@ -477,6 +479,8 @@ loopEntry:
         while(AppRunning(true))
         {
             showFrame();
+
+            checkAndDoDRCScreenOff();
 
             if(vpad.trigger & VPAD_BUTTON_B)
             {

--- a/src/menu/mainMenu.c
+++ b/src/menu/mainMenu.c
@@ -103,6 +103,8 @@ void mainMenu()
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_B)
         {
             if(showExitOverlay(true))

--- a/src/menu/menuUtils.c
+++ b/src/menu/menuUtils.c
@@ -473,6 +473,12 @@ bool showExitOverlay(bool really)
     return ret;
 }
 
+void checkAndDoDRCScreenOff() {
+    if (vpad.trigger & VPAD_BUTTON_STICK_R) {
+        VPADSetLcdMode(VPAD_CHAN_0, VPAD_LCD_STANDBY);
+    }
+}
+
 void humanize(uint64_t size, char *out)
 {
     const char *m;

--- a/src/menu/predownloadMenu.c
+++ b/src/menu/predownloadMenu.c
@@ -459,6 +459,8 @@ naNedNa:
             }
             showFrame();
 
+            checkAndDoDRCScreenOff();
+
             if(vpad.trigger & VPAD_BUTTON_B)
             {
                 freeRamBuf(rambuf);
@@ -561,6 +563,8 @@ naNedNa:
 
                 showFrame();
 
+                checkAndDoDRCScreenOff();
+
                 if(vpad.trigger & VPAD_BUTTON_B)
                 {
                     removeErrorOverlay(ovl);
@@ -592,6 +596,8 @@ naNedNa:
                         continue;
 
                     showFrame();
+
+                    checkAndDoDRCScreenOff();
 
                     if(vpad.trigger & VPAD_BUTTON_B)
                         break;
@@ -630,6 +636,8 @@ naNedNa:
 
                             showFrame();
 
+                            checkAndDoDRCScreenOff();
+
                             if(vpad.trigger & VPAD_BUTTON_B)
                                 break;
                             if(vpad.trigger & VPAD_BUTTON_A)
@@ -663,6 +671,8 @@ naNedNa:
                             continue;
 
                         showFrame();
+
+                        checkAndDoDRCScreenOff();
 
                         if(vpad.trigger & VPAD_BUTTON_B)
                             break;
@@ -717,6 +727,8 @@ naNedNa:
                             continue;
 
                         showFrame();
+
+                        checkAndDoDRCScreenOff();
 
                         if(vpad.trigger & VPAD_BUTTON_B)
                             break;

--- a/src/menu/queueMenu.c
+++ b/src/menu/queueMenu.c
@@ -146,6 +146,8 @@ bool queueMenu()
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_B)
             return false;
 

--- a/src/menu/titlebrowserMenu.c
+++ b/src/menu/titlebrowserMenu.c
@@ -232,6 +232,8 @@ loop:
         }
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_A)
         {
             entry = filteredTitleEntries[cursor + pos];

--- a/src/menu/updateMenu.c
+++ b/src/menu/updateMenu.c
@@ -65,6 +65,8 @@ bool updateMenu(const char *newVersion, NUSSPLI_TYPE type)
 
         showFrame();
 
+        checkAndDoDRCScreenOff();
+
         if(vpad.trigger & VPAD_BUTTON_A)
         {
             if(update(newVersion, type))


### PR DESCRIPTION
This PR makes it so that you can press the right stick button to put the gamepad into standby mode making it not drain as much power until you press any button
This uses the `VPADSetLcdMode` API call and because of how the input handling works here I just put my function that checks and runs it at every input loop
I'd use the TV button for this but that would mean not being able to take screenshots so yeah