### PR TITLE
specify docker.io specifically for devkitpro OCI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devkitpro/devkitppc:20250102
+FROM docker.io/devkitpro/devkitppc:20250102
 COPY --from=ghcr.io/wiiu-env/libmocha:20240603 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/librpxloader:20240425 /artifacts $DEVKITPRO
 


### PR DESCRIPTION
prefix the devkitpro image with "docker.io/" to support other OCI builders (e.g. podman)